### PR TITLE
Reload babybook entries when screen is focused

### DIFF
--- a/screens/BabyBookScreen.js
+++ b/screens/BabyBookScreen.js
@@ -116,7 +116,7 @@ class BabyBookScreen extends Component {
       this.props.fetchSubject();
     }
 
-    this.props.fetchBabyBookEntries();
+    //this.props.fetchBabyBookEntries();
 
     // bind function to navigation
     this.props.navigation.setParams({
@@ -140,6 +140,17 @@ class BabyBookScreen extends Component {
     if (!isEmpty(this.props.babybook.entries.data)) {
       this.props.navigation.setParams({ babybookEntries: true });
     }
+    this.willFocusBabyBook = this.props.navigation.addListener(
+      'willFocus',
+      () => {
+        this.props.fetchBabyBookEntries();
+      }
+    );
+  }
+
+  componentWillUnmount() {
+    // Remove nav focus listener
+    this.willFocusBabyBook.remove();
   }
 
   componentWillReceiveProps(nextProps) {


### PR DESCRIPTION
New babybook entries weren't being displayed if the Babybook screen was already in the navigation stack.  The reason being is that componentWillMount and componentWillUpdate weren't being called because the screen was already included in the stack.  My workaround was to call the fetchBabyBookEntries in the navigation lifecycle's willFocus event.  This event gets called whenever the screen is coming into focus, including after originally mounting.

https://reactnavigation.org/docs/en/navigation-prop.html#addlistener-subscribe-to-updates-to-navigation-lifecycle